### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Requirements
 
         * Ubuntu
 
-            * Xenial (16.04)
             * Bionic (18.04)
             * Focal (20.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,7 +15,6 @@ galaxy_info:
         - 31
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
     - name: Debian

--- a/molecule/ubuntu_min/molecule.yml
+++ b/molecule/ubuntu_min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible_role_antigen_bundles_ubuntu_min
-    image: ubuntu:16.04
+    image: ubuntu:18.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Xenial.